### PR TITLE
fix: 修复dark模式刷新页面后，Code代码阴影问题

### DIFF
--- a/packages/website/components/Markdown/Code.tsx
+++ b/packages/website/components/Markdown/Code.tsx
@@ -10,9 +10,13 @@ import { ThemeContext } from "../../utils/themeContext";
 export function CodeBlock(props: { children: any; match: any }) {
   const code = props.children.replace(/\n$/, "");
   const { theme } = useContext(ThemeContext);
-  const codeStyle = useMemo(() => {
-    if (theme.includes("dark")) { return dark }
-    return light as any
+
+  const curModeInfo = useMemo(() => {
+    const mode = theme.includes('dark') ? dark : light
+    return {
+      mode,
+      key: Date.now()
+    }
   }, [theme])
 
   return (
@@ -54,7 +58,8 @@ export function CodeBlock(props: { children: any; match: any }) {
         </div>
 
         <SyntaxHighlighter
-          style={codeStyle}
+          key={curModeInfo.key}
+          style={curModeInfo.mode}
           language={props.match?.length ? props.match[1] : undefined}
           wrapLines={true}
           lineProps={() => {


### PR DESCRIPTION
###    ###Description
#162 
文章详情页刷新后，code组件会变得模糊，原因是修改的dark主题未生效，使用的依然是默认的light主题，添加Key键强制刷新主题。

![image](https://user-images.githubusercontent.com/14230248/223054824-9c4b4ee5-4b05-437e-9a71-94b004d686b1.png)


### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files) 