### PR TITLE
fix: 修复auto、dark模式下在刷新后，code模块未同步的情况

### DIFF
--- a/packages/website/components/Markdown/Code.tsx
+++ b/packages/website/components/Markdown/Code.tsx
@@ -1,5 +1,5 @@
 import dynamic from "next/dynamic";
-import { useContext, useMemo } from "react";
+import { useContext, useState, useEffect } from "react";
 import CopyToClipboard from "react-copy-to-clipboard";
 import toast from "react-hot-toast";
 import { CodeComponent, CodeProps } from "react-markdown/lib/ast-to-react";
@@ -10,13 +10,10 @@ import { ThemeContext } from "../../utils/themeContext";
 export function CodeBlock(props: { children: any; match: any }) {
   const code = props.children.replace(/\n$/, "");
   const { theme } = useContext(ThemeContext);
+  const [curMode, setCurMode] = useState(undefined);
 
-  const curModeInfo = useMemo(() => {
-    const mode = theme.includes("dark") ? dark : (light as any);
-    return {
-      mode,
-      key: Date.now(),
-    };
+  useEffect(() => {
+    setCurMode(theme.includes("dark") ? dark : (light as any));
   }, [theme]);
 
   return (
@@ -58,8 +55,7 @@ export function CodeBlock(props: { children: any; match: any }) {
         </div>
 
         <SyntaxHighlighter
-          key={curModeInfo.key}
-          style={curModeInfo.mode}
+          style={curMode}
           language={props.match?.length ? props.match[1] : undefined}
           wrapLines={true}
           lineProps={() => {


### PR DESCRIPTION
###  Description
#226 
auto模式下，依然会出现code模糊的问题，修复此问题。
`react-syntax-highlighter` style属性直接设置为dark或者light常量，可以正常生效，但是用useMemo或者其他方式包裹后返回的变量，始终无法完成正常的初始化。
解决方案：mode初始值设置为undefined，根据theme重新设置。



### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Enhancement (changes that improvement of current feature or performance)
- [ ] Refactoring (changes that neither fixes a bug nor adds a feature)
- [ ] Test Case (changes that add missing tests or correct existing tests)
- [ ] Code style optimization (changes that do not affect the meaning of the code)
- [ ] Docs (changes that only update documentation)
- [ ] Chore (changes that don't modify src or test files) 