### PR TITLE
[Feat] Response post path name instead of id in search API

### DIFF
--- a/packages/server/src/provider/article/article.provider.ts
+++ b/packages/server/src/provider/article/article.provider.ts
@@ -912,7 +912,7 @@ export class ArticleProvider {
   toSearchResult(articles: Article[]) {
     return articles.map((each) => ({
       title: each.title,
-      id: each.id,
+      id: each.pathname ? each.pathname : each.id,
       category: each.category,
       tags: each.tags,
       updatedAt: each.updatedAt,


### PR DESCRIPTION
https://github.com/Mereithhh/vanblog/issues/356
这是一个未经测试的修改，因为我本地没有部署 Vanblog 的开发环境。  
这是我的修改依据：
1. 依据 [API 监听路径](https://github.com/Mereithhh/vanblog/blob/a77f4d6981688772de36bd22de385bc6f573cfbb/packages/server/src/controller/public/public.controller.ts#L72C18-L72C18) 找到此问题与 `articleProvider.toSearchResult` 与 `articleProvider.searchByString` 有关
2. 阅读后发现，`articleProvider.searchByString` 中的查询结果应该会返回完整的文章对象（`articleModel`），其中包含 `pathname` 字段
3. 而在 `articleProvider.toSearchResult` 中筛选了返回的字段，故判断可在此函数内加入判断